### PR TITLE
Token data pull unification

### DIFF
--- a/loader.lua
+++ b/loader.lua
@@ -480,12 +480,7 @@ local function parseCardData(cardID, data, onSuccess, incSem, decSem)
                 return
             end
 
-            table.insert(tokenData, {
-                name = name,
-                desc = collectOracleText(data),
-                front = pickImageURI(data),
-                back = getCardBack()
-            })
+
             -- Add it to the tokens list
             token.name = getAugmentedName(data)
             token.oracleText = collectOracleText(data)
@@ -503,12 +498,24 @@ local function parseCardData(cardID, data, onSuccess, incSem, decSem)
                         oracleText = token.oracleText
                     }
                 end
+                table.insert(tokenData, {
+                    name = name,
+                    desc = collectOracleText(data),
+                    front = token['faces'][1].imageURI,
+                    back = token['faces'][2].imageURI
+                })
             else
                 token['faces'][1] = {
                     imageURI = pickImageURI(data),
                     name = token.name,
                     oracleText = token.oracleText
                 }
+                table.insert(tokenData, {
+                    name = name,
+                    desc = collectOracleText(data),
+                    front = token['faces'][1].imageURI,
+                    back = getCardBack()
+                })
             end
             decSem()
         end)

--- a/loader.lua
+++ b/loader.lua
@@ -229,6 +229,7 @@ local function jsonForCardFace(face, position)
                 local pZ = -1.04
                 for i, token in ipairs(tokens) do
                     self.createButton({label = token.name,
+                        tooltip = "Create " .. token.name .. "\n" .. token.desc,
                         click_function = "gt" .. i,
                         function_owner = self,
                         width = math.max(400, 40 * string.len(token.name) + 40),


### PR DESCRIPTION
all token data is pulled in the same place and saved for token creation, no second call to fetchCardData and the Semaphore control waits only in one place

Forks from the 3/28 changes and re-implements the part.id and short emblem name fixes.